### PR TITLE
Fix for gh-pages Deployment

### DIFF
--- a/proto-app/package.json
+++ b/proto-app/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "A Glasswall template for CRA with a Glasswall NPM library pre-loaded. To enforce a consistent codebase and allow for our frontend styles to come together from pre-packaged NPM modules.",
   "main": "template.json",
-  "homepage": "https://filetrust.github.io/icap-management-ui/",
+  "homepage": "https://k8-proxy.github.io/p-ui-wireframes/",
   "author": "glasswallsolutions",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Since moving the repository from the FileTrust organisation, the gh-pages deployment was broken.

Changing the homepage in package.json fixed the site not being able to find assets.